### PR TITLE
add #utility_001:hologram_util/air

### DIFF
--- a/000_chens_utility/data/utility_001/functions/hologram_util/core/cursor/recursive.mcfunction
+++ b/000_chens_utility/data/utility_001/functions/hologram_util/core/cursor/recursive.mcfunction
@@ -2,4 +2,4 @@
 # @internal
 
 execute if entity @s[distance=..10] positioned ~ ~-0.15 ~ if entity @e[tag=hologram_collider_001,distance=..0.15,sort=nearest,limit=1] run scoreboard players operation @s hologram_id_001 = @e[tag=hologram_collider_001,distance=..0.15,sort=nearest,limit=1] hologram_id_001
-execute if entity @s[distance=..10] positioned ~ ~-0.15 ~ unless entity @e[tag=hologram_collider_001,distance=..0.15,sort=nearest,limit=1] positioned ~ ~0.15 ~ positioned ^ ^ ^0.0375 if block ~ ~ ~ air run function utility_001:hologram_util/core/cursor/recursive
+execute if entity @s[distance=..10] positioned ~ ~-0.15 ~ unless entity @e[tag=hologram_collider_001,distance=..0.15,sort=nearest,limit=1] positioned ~ ~0.15 ~ positioned ^ ^ ^0.0375 if block ~ ~ ~ #utility_001:hologram_util/air run function utility_001:hologram_util/core/cursor/recursive

--- a/000_chens_utility/data/utility_001/tags/blocks/hologram_util/air.json
+++ b/000_chens_utility/data/utility_001/tags/blocks/hologram_util/air.json
@@ -1,0 +1,8 @@
+{
+    "values": [
+        "minecraft:air",
+        "minecraft:cave_air",
+        "minecraft:void_air",
+        "minecraft:barrier"
+    ]
+}


### PR DESCRIPTION
クレー射撃にてhologram_utilのカーソルがbarrierを通り抜ける必要があったので、勝手ながら空気判定をタグにまとめました